### PR TITLE
how-to-build-totalcross-vm-wip: Fix typo in copy command

### DIFF
--- a/documentation/developers-area/how-to-build-totalcross-vm-wip.md
+++ b/documentation/developers-area/how-to-build-totalcross-vm-wip.md
@@ -199,6 +199,6 @@ TotalCross
 Look to the `bin` folder, now you just need to copy `libtcvm.so` to your valid SDK folder
 
 ```text
-~TotalCrossVM/builders/gcc-linux-arm/tcvm$ cp bin/libtcvm.so $PATH_TO_VALID_SDK/dist/vm/linux_ar
+~TotalCrossVM/builders/gcc-linux-arm/tcvm$ cp bin/libtcvm.so $PATH_TO_VALID_SDK/dist/vm/linux_arm
 ```
 


### PR DESCRIPTION
Fix the typo in the command that copy the artifacts to
$PATH_TO_VALID_SDK/dist/vm/linux_arm

Signed-off-by: Matheus Castello <matheus@castello.eng.br>